### PR TITLE
Add color-coded calendar for version releases

### DIFF
--- a/site/build_site.py
+++ b/site/build_site.py
@@ -66,6 +66,7 @@ class ChangelogEntry:
     title: str
     content: str
     html_content: str
+    has_new_version: bool
 
     @property
     def url(self) -> str:
@@ -100,6 +101,11 @@ def discover_changelogs() -> list[ChangelogEntry]:
         else:
             title = f"Changelog for {entry_date.strftime('%B %d, %Y')}"
 
+        # Check if changelog contains a new version release
+        has_new_version = bool(
+            re.search(r"^##\s+New Claude Code versions", content, re.MULTILINE)
+        )
+
         entries.append(
             ChangelogEntry(
                 date=entry_date,
@@ -107,6 +113,7 @@ def discover_changelogs() -> list[ChangelogEntry]:
                 title=title,
                 content=content,
                 html_content=html_content,
+                has_new_version=has_new_version,
             )
         )
 
@@ -123,11 +130,14 @@ def build_month_grid(year: int, month: int, changelog_dates: dict, viewing_date:
             if day.month != month:
                 week_data.append({"number": None, "has_changelog": False})
             else:
-                has_changelog = day in changelog_dates
+                changelog = changelog_dates.get(day)
+                has_changelog = changelog is not None
+                has_version = has_changelog and changelog.has_new_version
                 week_data.append(
                     {
                         "number": day.day,
                         "has_changelog": has_changelog,
+                        "has_version": has_version,
                         "is_current": day == viewing_date,
                         "url": f"/{day.year}/{day.month:02d}/{day.day:02d}.html"
                         if has_changelog

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -279,6 +279,36 @@ a:hover {
     font-weight: 600;
 }
 
+.calendar-legend {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.legend-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.legend-dot.version {
+    background: var(--color-accent);
+}
+
+.legend-dot.docs {
+    background: var(--color-highlight);
+}
+
 .calendar-nav-btn {
     background: none;
     border: none;
@@ -352,9 +382,29 @@ a:hover {
     background: var(--color-link-hover);
 }
 
+/* Version release days get accent color */
+.calendar td.has-version a {
+    background: var(--color-accent);
+    color: var(--color-header-bg);
+}
+
+.calendar td.has-version a:hover {
+    background: #e68a00;
+}
+
+[data-theme="dark"] .calendar td.has-version a:hover,
+:root:not([data-theme="light"]) .calendar td.has-version a:hover {
+    background: #e6a817;
+}
+
 .calendar td.current a {
     background: var(--color-highlight-dark);
     box-shadow: 0 0 0 2px var(--color-highlight);
+}
+
+.calendar td.current.has-version a {
+    background: #cc7a00;
+    box-shadow: 0 0 0 2px var(--color-accent);
 }
 
 /* Archive */

--- a/site/templates/partials/calendar.html
+++ b/site/templates/partials/calendar.html
@@ -4,6 +4,10 @@
         <h3 id="calendar-title"></h3>
         <button class="calendar-nav-btn" id="cal-next" aria-label="Next month">&rarr;</button>
     </div>
+    <div class="calendar-legend">
+        <span class="legend-item"><span class="legend-dot version"></span> New version</span>
+        <span class="legend-item"><span class="legend-dot docs"></span> Docs only</span>
+    </div>
 
     {% for month in calendar.months %}
     <table class="calendar" data-month-index="{{ loop.index0 }}" {% if loop.index0 != calendar.current_index %}style="display: none;"{% endif %}>
@@ -22,7 +26,7 @@
             {% for week in month.weeks %}
             <tr>
                 {% for day in week %}
-                <td class="{% if day.has_changelog %}has-entry{% endif %}{% if day.is_current %} current{% endif %}">
+                <td class="{% if day.has_changelog %}has-entry{% endif %}{% if day.has_version %} has-version{% endif %}{% if day.is_current %} current{% endif %}">
                     {% if day.has_changelog %}
                         <a href="{{ base_url }}{{ day.url }}">{{ day.number }}</a>
                     {% elif day.number %}


### PR DESCRIPTION
## Summary

- Days with new Claude Code version releases are now displayed in orange/amber color
- Documentation-only changelog days remain blue
- Added a legend to the calendar explaining the color coding

Closes #4

## Test plan

- [ ] Build site locally with `uv run site/build_site.py`
- [ ] Open `_site/index.html` and verify calendar shows orange dots for version release days
- [ ] Verify blue dots for documentation-only days
- [ ] Verify legend is visible below the month header
- [ ] Check both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)